### PR TITLE
Add instructions to install using conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ pip install .
 
 # Option 2: Install directly from GitHub
 pip install git+https://github.com/sayitobar/fishplotpy.git
+
+# Option 3: Install using conda
+conda install -c conda-forge -c bioconda fishplotpy
 ```
 
 **Dependencies:**


### PR DESCRIPTION
This adds a third option to the README showing how to install with the newly created [conda package](https://github.com/bioconda/bioconda-recipes/pull/58132) (see #1)